### PR TITLE
feat: Set `ignoreUndefinedProperties` in Firestore settings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ An options object to pass to the Firebase Admin SDK's `initializeApp` method. Th
 
 Prefix for the boardgame.io collections within your Firebase project.
 
+### `ignoreUndefinedProperties`
+
+- **type:** `boolean`
+- **default:** `true`
+
+By default, the Firestore instance’s [`settings` method][settings] is called
+internally to avoid errors from `undefined` values in data from boardgame.io.
+`settings` can only be called once, so if you want to call it with your own
+custom options, you can pass `false` here to disable the internal call.
+
 
 ## Database structure
 
@@ -132,6 +142,7 @@ The code in this repository is provided under [the MIT License][license].
 [0.39cl]: https://github.com/nicolodavis/boardgame.io/blob/master/docs/documentation/CHANGELOG.md#v0390
 [fbsetup]: https://firebase.google.com/docs/admin/setup#node.js
 [appopts]: https://firebase.google.com/docs/reference/admin/node/admin.AppOptions
+[settings]: https://googleapis.dev/nodejs/firestore/latest/Firestore.html#settings
 [dbstruct]: #database-structure
 [newissue]: https://github.com/delucis/bgio-firebase/issues/new/choose
 [COC]: CODE_OF_CONDUCT.md

--- a/src/db/firestore.ts
+++ b/src/db/firestore.ts
@@ -11,7 +11,12 @@ export class Firestore extends Async {
   readonly initialState: admin.firestore.CollectionReference;
   readonly log: admin.firestore.CollectionReference;
 
-  constructor({ app, config, dbPrefix = DB_PREFIX }: FirebaseDBOpts = {}) {
+  constructor({
+    app,
+    config,
+    dbPrefix = DB_PREFIX,
+    ignoreUndefinedProperties = true,
+  }: FirebaseDBOpts = {}) {
     super();
     this.client = admin;
     const hasNoInitializedApp = this.client.apps.length === 0;
@@ -21,6 +26,9 @@ export class Firestore extends Async {
       this.client.initializeApp(config, app);
     }
     this.db = this.client.app(app).firestore();
+    if (ignoreUndefinedProperties) {
+      this.db.settings({ ignoreUndefinedProperties });
+    }
     this.metadata = this.db.collection(dbPrefix + DBTable.Metadata);
     this.state = this.db.collection(dbPrefix + DBTable.State);
     this.initialState = this.db.collection(dbPrefix + DBTable.InitialState);

--- a/src/db/shared.ts
+++ b/src/db/shared.ts
@@ -4,6 +4,7 @@ export interface FirebaseDBOpts {
   app?: string;
   config?: admin.AppOptions;
   dbPrefix?: string;
+  ignoreUndefinedProperties?: boolean;
 }
 
 export const DB_PREFIX = 'bgio_';

--- a/test/bgio-firebase.test.ts
+++ b/test/bgio-firebase.test.ts
@@ -20,6 +20,7 @@ describe('Firestore', () => {
     // instantiate new database instance for each test
     db = new Firestore({
       config: { projectId },
+      ignoreUndefinedProperties: false,
     });
     await db.connect();
   });
@@ -46,7 +47,7 @@ describe('Firestore', () => {
 
     test('custom database prefix', () => {
       const dbPrefix = 'a';
-      db = new Firestore({ dbPrefix });
+      db = new Firestore({ dbPrefix, ignoreUndefinedProperties: false });
       for (const table of tables) {
         const ref = db[table];
         expect(ref.id).toBe(dbPrefix + table);
@@ -54,7 +55,11 @@ describe('Firestore', () => {
     });
 
     test('can specify app name', () => {
-      db = new Firestore({ config: { projectId }, app: 'customApp' });
+      db = new Firestore({
+        config: { projectId },
+        app: 'customApp',
+        ignoreUndefinedProperties: false,
+      });
       expect(
         db.client.apps.some((app) => app && app.name === 'customApp')
       ).toBe(true);


### PR DESCRIPTION
This PR uses the new `ignoreUndefinedProperties` option by default to prevent errors generated when trying to persist `undefined` values.

Partially addresses #5.